### PR TITLE
Include SHA256SUMS file in the files attached to a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: age-binaries
+      - name: Checksum binaries
+        run: |
+          sha256sum age-* > age-SHA256SUMS
       - name: Upload release artifacts
         run: gh release upload "$GITHUB_REF_NAME" age-*
         env:


### PR DESCRIPTION
I'm absolutely not familiar with github actions so this might be the wrong way to do it (I have no way to check), but it can at least open the conversation about providing checksums to be able to verify downloads as requested in https://github.com/FiloSottile/age/issues/133#issuecomment-672123508.

This is not a security measure, all it does is allow users to pin binaries (failsafe an attached file is updated) and validate downloads (failsafe if the file was corrupted in the download). If security is required, signing would be a better bet (which is already done if you install from your distro repos).